### PR TITLE
upgrade numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ description = "Fast and Lightweight Text Embedding"
 readme = "README.md"
 authors = [{ name = "Binh Nguyen", email = "binhcode25@gmail.com" }]
 maintainers = [{name = "Binh Nguyen", email = "binhcode25@gmail.com"}]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = [
-    "numpy==1.26.4",
+    "numpy==2.3.1",
     "huggingface_hub==0.25.2",
     "onnxruntime==1.22.0",
     "tokenizers==0.21.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [{name = "Binh Nguyen", email = "binhcode25@gmail.com"}]
 requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = [
-    "numpy==2.3.1",
+    "numpy>=2",
     "huggingface_hub==0.25.2",
     "onnxruntime==1.22.0",
     "tokenizers==0.21.1"


### PR DESCRIPTION
To be used in common ground core:

An older NumPy version can easily cause dependency conflicts with other libraries, making them incompatible. I've upgraded the version here.